### PR TITLE
エラー発生時と無効なURL入力時の処理

### DIFF
--- a/app/js/music_page.js
+++ b/app/js/music_page.js
@@ -86,14 +86,23 @@ ws.onmessage = function (msg) {
     const obj = JSON.parse(msg.data);
     var url = obj.url;
 
-    cnt++;
-    queue.push(url);
-    check.push(cnt);
-    var n = "url" + cnt;
-    setTimeout(()=>{
-        var add = '<div id =' + n + ' class="list-container"><div class="flex-item list-url col-8">' + obj.title + '</div><div class="flex-item col-3"><input class="btn btn-outline-dark btn-del btn-danger" type="button" value="×" onclick="remove(this);"/></div></div>';
-        $('#wrapper').append(add).trigger('create');
+    if(obj.title){
+        cnt++;
+        queue.push(url);
+        check.push(cnt);
+        var n = "url" + cnt;
+        setTimeout(()=>{
+            var add = '<div id =' + n + ' class="list-container"><div class="flex-item list-url col-8">' + obj.title + '</div><div class="flex-item col-3"><input class="btn btn-outline-dark btn-del btn-danger" type="button" value="×" onclick="remove(this);"/></div></div>';
+            $('#wrapper').append(add).trigger('create');
         }, 200);    
+    }else{
+        swal({
+            title: "Wrong URL!!",
+            text: "Please try again.",
+            icon: "error",
+            dangerMode: true,
+        });
+    }
 };
 
 function SendButtonClick() {

--- a/app/js/music_page.js
+++ b/app/js/music_page.js
@@ -24,8 +24,10 @@ function onYouTubeIframeAPIReady() {
         width: "800",
         videoId: init_id.dataset.id,
         events: {
+            // 各イベントについて対応するコールバック関数を用意する
             "onReady": onPlayerReady,
-            "onStateChange": onPlayerStateChange
+            "onStateChange": onPlayerStateChange,
+            "onError": onPlayerError
         }
     });
 }
@@ -36,30 +38,42 @@ function onPlayerReady(event) {
 
 var done = false;
 function onPlayerStateChange(event) {
-    if (event.data == YT.PlayerState.ENDED) {
+    if (event.data == YT.PlayerState.ENDED) PlayNextVideo();
+}
 
-        //to do: videoIdがfalse -> 再生しないように後で実装する
+// 動画の再生処理の部分
+function PlayNextVideo(){
+    //to do: videoIdがfalse -> 再生しないように後で実装する
         
-        while(check[0] == -1 && check.length > 0){
-            queue.shift();
-            check.shift();
-        }
-        
-        var id_tmp = '#url' + check[0];
-        $(id_tmp).remove();
-        var url = queue.shift();
+    while(check[0] == -1 && check.length > 0){
+        queue.shift();
         check.shift();
-        videoId = url.split('v=')[1];
-
-        if (videoId) {
-            // &=クエリパラーメターがついていることがあるので取り除く
-            const ampersandPosition = videoId.indexOf('&');
-            if(ampersandPosition != -1) {
-                videoId = videoId.substring(0, ampersandPosition);
-            }
-        }
-        player.loadVideoById(videoId)
     }
+    
+    var id_tmp = '#url' + check[0];
+    $(id_tmp).remove();
+    var url = queue.shift();
+    check.shift();
+    videoId = url.split('v=')[1];
+
+    if (videoId) {
+        // &=クエリパラーメターがついていることがあるので取り除く
+        const ampersandPosition = videoId.indexOf('&');
+        if(ampersandPosition != -1) {
+            videoId = videoId.substring(0, ampersandPosition);
+        }
+    }
+    player.loadVideoById(videoId)
+}
+
+function onPlayerError(event){
+    swal({
+        title: "Can't play this video...",
+        text: "We play next video.",
+        icon: "error",
+        dangerMode: true,
+    });
+    PlayNextVideo();
 }
 
 function stopVideo(){
@@ -96,7 +110,7 @@ function SendButtonClick() {
             text: "Please try again.",
             icon: "error",
             dangerMode: true,
-        })
+        });
     }
     text.value = "";
 };

--- a/app/js/music_page.js
+++ b/app/js/music_page.js
@@ -32,11 +32,12 @@ function onYouTubeIframeAPIReady() {
     });
 }
 
+// 再生準備完了時
 function onPlayerReady(event) {
     event.target.playVideo();
 }
 
-var done = false;
+// 動画の状態変化時
 function onPlayerStateChange(event) {
     if (event.data == YT.PlayerState.ENDED) PlayNextVideo();
 }
@@ -66,6 +67,7 @@ function PlayNextVideo(){
     player.loadVideoById(videoId)
 }
 
+// エラー発生時
 function onPlayerError(event){
     swal({
         title: "Can't play this video...",
@@ -85,7 +87,7 @@ var cnt = 0
 ws.onmessage = function (msg) {
     const obj = JSON.parse(msg.data);
     var url = obj.url;
-
+    // obj.titleがないときはその動画を弾く
     if(obj.title){
         cnt++;
         queue.push(url);

--- a/app/main.go
+++ b/app/main.go
@@ -150,6 +150,7 @@ func main() {
 				return q.Request.URL.Path == s.Request.URL.Path
 			})
 		}else{
+			// 自分のみにRedirect
 			s.Write(send_data_json)
 		}
 	})

--- a/app/main.go
+++ b/app/main.go
@@ -143,6 +143,8 @@ func main() {
 		})
 
 		send_data_json, _ := json.Marshal(send_data)
+
+		// send_data.Titleの長さが0の時は無効なURLとする
 		if(len(send_data.Title) != 0){
 			m.BroadcastFilter(send_data_json, func(q *melody.Session) bool {
 				return q.Request.URL.Path == s.Request.URL.Path

--- a/app/main.go
+++ b/app/main.go
@@ -143,10 +143,13 @@ func main() {
 		})
 
 		send_data_json, _ := json.Marshal(send_data)
-
-		m.BroadcastFilter(send_data_json, func(q *melody.Session) bool {
-			return q.Request.URL.Path == s.Request.URL.Path
-		})
+		if(len(send_data.Title) != 0){
+			m.BroadcastFilter(send_data_json, func(q *melody.Session) bool {
+				return q.Request.URL.Path == s.Request.URL.Path
+			})
+		}else{
+			s.Write(send_data_json)
+		}
 	})
 
 	router.Run(":8080")


### PR DESCRIPTION
1. music_page.jsにおいてonErrorイベント発生時にアラートを出して次の動画を再生するようにしたコールバック関数onPlayerErrorの実装。
2. 1の実装にあたって元々YT.PlayerState.ENDEDが発生した際に実行していた部分を関数分離してエラー発生時にも使えるようにした。
3. main.goにおいて、len(send_data.Title)が0の時には送った本人にしかそのデータを流さないようにした。
4. 3を受けて、music_page.jsのonmessageでobj.titleがないときにはその動画をキューに追加せずアラートを発生するようにした。